### PR TITLE
IPv6 fixes

### DIFF
--- a/src/Tingle.AspNetCore.Authorization/ApprovedIPNetworkHandler.cs
+++ b/src/Tingle.AspNetCore.Authorization/ApprovedIPNetworkHandler.cs
@@ -35,7 +35,7 @@ namespace Tingle.AspNetCore.Authorization
         {
             var httpContext = httpContextAccessor.HttpContext;
             var address = httpContext.Connection.RemoteIpAddress;
-            logger.LogTrace("Checking approval for IP: '{0}', IPv4MappedToIPv6: {1}", address, address?.IsIPv4MappedToIPv6);
+            logger.LogTrace("Checking approval for IP: '{0}'", address);
             if (address != null && requirement.IsApproved(address))
             {
                 context.Succeed(requirement);

--- a/src/Tingle.AspNetCore.Authorization/ApprovedIPNetworkRequirement.cs
+++ b/src/Tingle.AspNetCore.Authorization/ApprovedIPNetworkRequirement.cs
@@ -27,6 +27,16 @@ namespace Tingle.AspNetCore.Authorization
         /// </summary>
         /// <param name="address">The address to check.</param>
         /// <returns></returns>
-        public bool IsApproved(IPAddress address) => networks.Contains(address);
+        public bool IsApproved(IPAddress address)
+        {
+            // if the IP is an IPv4 mapped to IPv6, remap it
+            var addr = address;
+            if (addr.IsIPv4MappedToIPv6)
+            {
+                addr = addr.MapToIPv4();
+            }
+
+            return networks.Contains(addr);
+        }
     }
 }

--- a/tests/Tingle.AspNetCore.Authorization.Tests/ApprovedIPNetworksTests.cs
+++ b/tests/Tingle.AspNetCore.Authorization.Tests/ApprovedIPNetworksTests.cs
@@ -14,11 +14,13 @@ namespace Tingle.AspNetCore.Authorization.Tests
         [InlineData(false, "127.0.1.1", "127.0.0.1/32,::1/128")]
         [InlineData(false, "127.0.1.1", "192.201.214.0/24,::1/128")]
         [InlineData(false, "30.0.0.21", "192.201.214.0/24")]
+        [InlineData(false, "2001:0000:0000:1234:abcd:ffff:c0a8:0101", "2002::1234:abcd:ffff:c0a8:101/64")]
         [InlineData(true, "207.154.225.144", "207.154.225.144/32")]
         [InlineData(true, "196.201.214.94", "196.201.214.0/24")]
         [InlineData(true, "196.201.214.94", "196.201.214.0/24,30.0.0.0/27")]
         [InlineData(true, "30.0.0.21", "196.201.214.0/24,30.0.0.0/27")]
         [InlineData(true, "::ffff:196.201.214.127", "196.201.214.0/24")] // IPv4 mapped to IPv6
+        [InlineData(true, "2002:0000:0000:1234:abcd:ffff:c0a8:0101", "2002::1234:abcd:ffff:c0a8:101/64")]
         public void IsApproved_Works(bool expected, string test, string networks)
         {
             var builder = new AuthorizationPolicyBuilder();

--- a/tests/Tingle.AspNetCore.Authorization.Tests/ApprovedIPNetworksTests.cs
+++ b/tests/Tingle.AspNetCore.Authorization.Tests/ApprovedIPNetworksTests.cs
@@ -14,10 +14,11 @@ namespace Tingle.AspNetCore.Authorization.Tests
         [InlineData(false, "127.0.1.1", "127.0.0.1/32,::1/128")]
         [InlineData(false, "127.0.1.1", "192.201.214.0/24,::1/128")]
         [InlineData(false, "30.0.0.21", "192.201.214.0/24")]
+        [InlineData(true, "207.154.225.144", "207.154.225.144/32")]
         [InlineData(true, "196.201.214.94", "196.201.214.0/24")]
         [InlineData(true, "196.201.214.94", "196.201.214.0/24,30.0.0.0/27")]
         [InlineData(true, "30.0.0.21", "196.201.214.0/24,30.0.0.0/27")]
-        [InlineData(true, "207.154.225.144", "207.154.225.144/32")]
+        [InlineData(true, "::ffff:196.201.214.127", "196.201.214.0/24")] // IPv4 mapped to IPv6
         public void IsApproved_Works(bool expected, string test, string networks)
         {
             var builder = new AuthorizationPolicyBuilder();


### PR DESCRIPTION
This PR fixes issues related to IPv6  handling for authorization:
- Ensure IPv6 CIDRs and addresses work.
- IPv4 addresses mapped to IPv6 should be mapped back before checking if they are allowed.